### PR TITLE
Refactor output file paths in omics.config for execution reports

### DIFF
--- a/conf/omics.config
+++ b/conf/omics.config
@@ -4,22 +4,28 @@ params {
     ntc_regex = 'NTC'
 }
 
-def trace_timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
-timeline {
-    enabled = true
-    file    = "${params.outdir}/pipeline_info/execution_timeline_${trace_timestamp}.html"
-}
 report {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/execution_report_${trace_timestamp}.html"
+    file = '/mnt/workflow/output/report.html'
+    overwrite = true
 }
+
+timeline {
+    enabled = true
+    file = '/mnt/workflow/output/timeline.html'
+    overwrite = true
+}
+
 trace {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/execution_trace_${trace_timestamp}.txt"
+    file = '/mnt/workflow/output/trace.txt'
+    overwrite = true
 }
+
 dag {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/pipeline_dag_${trace_timestamp}.html"
+    file = '/mnt/workflow/output/dag.html'
+    overwrite = true
 }
 
 manifest {


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/spntypeid/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/spntypeid _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).

## Added pipeline report configuration for Omics
This pull request updates the output configuration for pipeline reporting in `omics.config`. The main changes standardize the output file locations and enable automatic overwriting of report files, ensuring that outputs are consistently written to the `/mnt/workflow/output/` directory instead of including timestamps in their filenames.

**Output file management improvements:**

* All pipeline report files (`report.html`, `timeline.html`, `trace.txt`, `dag.html`) are now saved to the `/mnt/workflow/output/` directory with fixed filenames, replacing the previous use of timestamped filenames in the `/mnt/workflow/pubdir/pipeline_info/` directory.
* The `overwrite` option is enabled for all reports, ensuring that each pipeline execution replaces existing output files rather than creating new ones with unique timestamps.

**Configuration simplification:**

* The `trace_timestamp` variable and its usage in file naming have been removed, simplifying the configuration and reducing potential clutter from multiple output files.